### PR TITLE
feat(codex-subagents): allow per-spawn model and thinking overrides

### DIFF
--- a/packages/pi-codex-subagents/README.md
+++ b/packages/pi-codex-subagents/README.md
@@ -75,6 +75,8 @@ Optional configuration lives at:
 {
   "storageDir": "~/.local/state/pi-codex-subagents/runs",
   "retentionDays": 7,
+  "models": ["openai-codex/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
+  "modelsFromEnabledModels": true,
   "defaults": {
     "skills": ["web-investigate"],
     "extensions": ["@scope/pi-extra-tools"]
@@ -86,7 +88,30 @@ Optional configuration lives at:
 
 Configuration is read when agents spawn, while cleanup runs when the extension loads. Restart Pi after changing `storageDir` or `retentionDays` so storage lookup and cleanup use the same configuration throughout the process.
 
-Template skills and extensions override configured defaults. Skills explicitly requested by the parent are added to configured template/default skills. Tool selection belongs to the template or is inherited from the parent. A `model` requested by the parent as one `provider/model-id` argument, and a requested `thinking` level, override the template and the inherited values, so one task can run on another provider without a template.
+Template skills and extensions override configured defaults. Skills explicitly requested by the parent are added to configured template/default skills. Tool selection belongs to the template or is inherited from the parent. A `model` and `thinking` level requested by the parent override the template and the inherited values, so one task can run on another model without a template.
+
+## Model routing
+
+An allowlist in `config.json` decides whether a parent may request a `model` and a `thinking` level per spawn, and which models it may pick. Both arguments appear together or not at all: an installation that configures nothing keeps routing in templates and inheritance. Two sources may be combined:
+
+- `models` lists exact `provider/model-id` pairs approved for this extension alone, independent of any Pi setting.
+- `modelsFromEnabledModels: true` adds the models Pi already scoped for the session, resolved from the `enabledModels` setting and `--models`. Models approved for the installation need no second approval here, and Pi has already expanded globs, preferred aliases over dated versions, and dropped unavailable entries. When Pi has no model scoping configured, this source adds nothing.
+
+The arguments are offered only when at least one allowed model is available, and `model` enumerates exactly those pairs:
+
+| Configuration | Allowed and available | `model` and `thinking` on the tool |
+|---|---|---|
+| neither key set | — | absent, routing belongs to templates |
+| `"modelsFromEnabledModels": true`, Pi scoping unset | — | absent |
+| `"modelsFromEnabledModels": true`, Pi scoping set | 2 models | present, `model` lists those 2 pairs |
+| `"models": ["typo/xyz"]` | nothing available | absent, entry reported as a notification |
+| both keys set | the union, deduplicated | present, `model` lists the union |
+
+The list is resolved when a session starts: `models` entries are filtered to what is currently available, unavailable entries are reported as a warning notification, and the scoped models are merged in. Editing the configuration or the Pi setting takes effect when the next session starts, matching the `storageDir` and `retentionDays` behavior above. If a provider drops out mid-session, `spawn_agent` refuses that model at spawn time instead of serving a stale route.
+
+An allowed model may belong to an extension-registered provider. Route to one only from a template that loads that provider extension, since children load none of their own.
+
+A thinking level written into an `enabledModels` pattern, such as `anthropic/claude-opus-4-6:high`, is ignored here. `thinking` stays a separate argument, and the child clamps it to what its model supports.
 
 ## Completion delivery
 

--- a/packages/pi-codex-subagents/README.md
+++ b/packages/pi-codex-subagents/README.md
@@ -86,7 +86,7 @@ Optional configuration lives at:
 
 Configuration is read when agents spawn, while cleanup runs when the extension loads. Restart Pi after changing `storageDir` or `retentionDays` so storage lookup and cleanup use the same configuration throughout the process.
 
-Template skills and extensions override configured defaults. Skills explicitly requested by the parent are added to configured template/default skills. Tool selection belongs to the template or is inherited from the parent.
+Template skills and extensions override configured defaults. Skills explicitly requested by the parent are added to configured template/default skills. Tool selection belongs to the template or is inherited from the parent. A `model` requested by the parent as one `provider/model-id` argument, and a requested `thinking` level, override the template and the inherited values, so one task can run on another provider without a template.
 
 ## Completion delivery
 

--- a/packages/pi-codex-subagents/core.test.ts
+++ b/packages/pi-codex-subagents/core.test.ts
@@ -218,48 +218,30 @@ function spawnParams(parentSessionId: string, task_name: string, message: string
   };
 }
 
-describe("spawn overrides", () => {
-  test("caller model/thinking win over inherited values", async () => {
+describe("spawn model and thinking resolution", () => {
+  test("caller wins, then the template, then the inherited value, then the default", async () => {
     process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
     const parentSessionId = "spawn-overrides";
-    fs.rmSync(path.join(getRunsDir(), parentScopeKey(parentSessionId)), { recursive: true, force: true });
-    const manager = new AgentManager();
-    try {
-      await manager.spawnAgent({ ...spawnParams(parentSessionId, "reviewer", "review"), inheritedThinking: "low", provider: "openai", modelId: "gpt-5", thinking: "xhigh" });
-      expect(manager.getAgentInfo("reviewer", parentSessionId)).toMatchObject({ provider: "openai", modelId: "gpt-5", model: "openai:gpt-5", thinking: "xhigh" });
-      await manager.spawnAgent({ ...spawnParams(parentSessionId, "plain", "work"), inheritedThinking: "low" });
-      expect(manager.getAgentInfo("plain", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "low" });
-      await manager.spawnAgent({ ...spawnParams(parentSessionId, "model-only", "work"), inheritedThinking: "low", provider: "openai", modelId: "gpt-5" });
-      expect(manager.getAgentInfo("model-only", parentSessionId)).toMatchObject({ model: "openai:gpt-5", thinking: "low" });
-      await manager.spawnAgent({ ...spawnParams(parentSessionId, "thinking-only", "work"), inheritedThinking: "low", thinking: "max" });
-      expect(manager.getAgentInfo("thinking-only", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "max" });
-      await expect(manager.spawnAgent({ ...spawnParams(parentSessionId, "half", "work"), provider: "openai" })).rejects.toThrow("needs both provider and modelId");
-    } finally {
-      await manager.shutdown();
-      delete process.env.PI_SUBAGENT_PI_BIN;
-    }
-  });
-
-  test("caller overrides beat a template, and each unset field falls back", async () => {
-    process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
-    const parentSessionId = "spawn-overrides-template";
     fs.rmSync(path.join(getRunsDir(), parentScopeKey(parentSessionId)), { recursive: true, force: true });
     const templateFile = path.join(TEST_AGENT_DIR, "pi-codex-subagents", "agents", "routed.md");
     fs.mkdirSync(path.dirname(templateFile), { recursive: true });
     fs.writeFileSync(templateFile, "---\nname: routed\nprovider: template-provider\nmodel: template-model\nthinking: medium\n---\nRouted template.");
     const manager = new AgentManager();
     const spawn = async (task: string, overrides: Record<string, unknown>) => {
-      await manager.spawnAgent({ ...spawnParams(parentSessionId, task, "work"), agent_type: "routed", inheritedThinking: "low", ...overrides });
+      await manager.spawnAgent({ ...spawnParams(parentSessionId, task, "work"), inheritedThinking: "low", ...overrides });
       return manager.getAgentInfo(task, parentSessionId);
     };
+    const callerModel = { model: { provider: "openai", modelId: "gpt-5" } };
     try {
-      expect(await spawn("template-wins", {})).toMatchObject({ model: "template-provider:template-model", thinking: "medium" });
-      expect(await spawn("caller-model", { provider: "openai", modelId: "gpt-5" })).toMatchObject({ model: "openai:gpt-5", thinking: "medium" });
-      expect(await spawn("caller-thinking", { thinking: "max" })).toMatchObject({ model: "template-provider:template-model", thinking: "max" });
-      expect(await spawn("caller-both", { provider: "openai", modelId: "gpt-5", thinking: "xhigh" })).toMatchObject({ model: "openai:gpt-5", thinking: "xhigh" });
-      await manager.spawnAgent(spawnParams(parentSessionId, "no-thinking-anywhere", "work"));
-      expect(manager.getAgentInfo("no-thinking-anywhere", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "high" });
-      await expect(manager.spawnAgent({ ...spawnParams(parentSessionId, "missing", "work"), agent_type: "absent" })).rejects.toThrow("Agent template not found");
+      expect(await spawn("inherited", {})).toMatchObject({ model: "test:fake", thinking: "low" });
+      expect(await spawn("caller-model", callerModel)).toMatchObject({ model: "openai:gpt-5", thinking: "low" });
+      expect(await spawn("caller-thinking", { thinking: "max" })).toMatchObject({ model: "test:fake", thinking: "max" });
+      expect(await spawn("template", { agent_type: "routed" })).toMatchObject({ model: "template-provider:template-model", thinking: "medium" });
+      expect(await spawn("caller-beats-template", { agent_type: "routed", ...callerModel, thinking: "xhigh" })).toMatchObject({ model: "openai:gpt-5", thinking: "xhigh" });
+      // No level requested anywhere, not even by the parent, falls back to the package default.
+      await manager.spawnAgent(spawnParams(parentSessionId, "default-thinking", "work"));
+      expect(manager.getAgentInfo("default-thinking", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "high" });
+      await expect(spawn("missing", { agent_type: "absent" })).rejects.toThrow("Agent template not found");
     } finally {
       await manager.shutdown();
       fs.rmSync(templateFile, { force: true });
@@ -596,34 +578,56 @@ describe("extension completion delivery and TUI", () => {
       getActiveTools() { return ["read", "bash"]; },
     };
     const parentSessionId = "index-integration-parent";
+    const availableModels = [
+      { provider: "test", id: "fake" },
+      { provider: "fireworks", id: "accounts/fireworks/models/glm-5p2" },
+      { provider: "openai", id: "gpt-5" },
+    ];
+    const notifications: string[] = [];
     const ctx: any = {
       cwd: TEST_AGENT_DIR,
       mode: "tui",
       model: { provider: "test", id: "fake" },
-      modelRegistry: {
-        getAvailable: () => [
-          { provider: "test", id: "fake" },
-          { provider: "fireworks", id: "accounts/fireworks/models/glm-5p2" },
-        ],
-      },
+      modelRegistry: { getAvailable: () => availableModels },
+      // What pi resolved the enabledModels patterns to for this session, availability-checked.
+      scopedModels: [
+        { model: { provider: "fireworks", id: "accounts/fireworks/models/glm-5p2" } },
+        { model: { provider: "openai", id: "gpt-5" } },
+      ],
       sessionManager: {
         getSessionId: () => parentSessionId,
         getSessionFile: () => path.join(TEST_AGENT_DIR, "parent.jsonl"),
       },
       ui: {
         setWidget(_key: string, value: any) { widget = value; },
+        notify(message: string) { notifications.push(message); },
       },
     };
     const scope = path.join(getRunsDir(), parentScopeKey(parentSessionId));
     fs.rmSync(scope, { recursive: true, force: true });
+    const configFile = path.join(TEST_AGENT_DIR, "pi-codex-subagents", "config.json");
+    // A thinking suffix on an allowlist entry is tolerated and stripped from the offered pair.
+    fs.writeFileSync(configFile, JSON.stringify({ models: ["test/fake:high", "typo/nope"], modelsFromEnabledModels: true }));
     const { default: subagentExtension } = await import("./index.js");
     subagentExtension(pi);
     const emit = async (name: string, event: any = {}) => {
       for (const handler of handlers.get(name) ?? []) await handler(event, ctx);
     };
 
+    // Session start is the single resolution point, so before it the arguments are absent.
+    const spawnArgs = () => tools.get("spawn_agent").parameters.properties;
+    expect(spawnArgs().model).toBeUndefined();
+    expect(spawnArgs().thinking).toBeUndefined();
+
     try {
+      // Session start is authoritative: allowlist entries filtered to what is available,
+      // unioned with pi's scoped models, and the schema must not wait for a first turn.
       await emit("session_start", { reason: "startup" });
+      expect(spawnArgs().model.enum).toEqual(["test/fake", "fireworks/accounts/fireworks/models/glm-5p2", "openai/gpt-5"]);
+      expect(spawnArgs().thinking.enum).toContain("max");
+      expect(notifications).toEqual(['spawn_agent models not available: typo/nope']);
+      // The values live in the schema, but the description has to say the capability exists.
+      expect(tools.get("spawn_agent").description).toContain("`model` takes one of the values its schema lists");
       expect(commands.has("agents")).toBe(true);
       expect(commands.has("subagent")).toBe(true);
       expect(commands.has("subagents")).toBe(true);
@@ -668,13 +672,26 @@ describe("extension completion delivery and TUI", () => {
         modelId: "accounts/fireworks/models/glm-5p2",
         thinking: "max",
       });
-      await expect(tools.get("spawn_agent").execute("spawn-4", { task_name: "unknown-id", message: "x", model: "fireworks/nope" }, undefined, undefined, ctx))
-        .rejects.toThrow("Model ids for fireworks: accounts/fireworks/models/glm-5p2");
-      await expect(tools.get("spawn_agent").execute("spawn-5", { task_name: "unqualified", message: "x", model: "gpt-5" }, undefined, undefined, ctx))
-        .rejects.toThrow('model must be "provider/model-id"');
+      // A model the registry has, but neither list allows, is refused.
+      await expect(tools.get("spawn_agent").execute("spawn-4", { task_name: "not-enabled", message: "x", model: "anthropic/claude-opus-4-6" }, undefined, undefined, ctx))
+        .rejects.toThrow(/not in the configured spawn models/);
+
+      // An allowlisted model whose provider dropped out mid-session is refused at spawn time,
+      // covering both availability drift and schemas frozen before the session started.
+      availableModels.splice(availableModels.findIndex((entry) => entry.provider === "openai"), 1);
+      await expect(tools.get("spawn_agent").execute("spawn-5", { task_name: "gone", message: "x", model: "openai/gpt-5" }, undefined, undefined, ctx))
+        .rejects.toThrow(/not currently available/);
+
+      // Unconfigured takes both runtime arguments away again even though Pi still has enabledModels.
+      fs.writeFileSync(configFile, "{}");
+      await emit("session_start", { reason: "restart" });
+      expect(spawnArgs().model).toBeUndefined();
+      expect(spawnArgs().thinking).toBeUndefined();
+      expect(tools.get("spawn_agent").description).not.toContain("`model` takes one of the values");
     } finally {
       await emit("session_shutdown", { reason: "quit" });
       fs.rmSync(scope, { recursive: true, force: true });
+      fs.rmSync(configFile, { force: true });
       delete process.env.PI_SUBAGENT_PI_BIN;
     }
   });

--- a/packages/pi-codex-subagents/core.test.ts
+++ b/packages/pi-codex-subagents/core.test.ts
@@ -218,6 +218,56 @@ function spawnParams(parentSessionId: string, task_name: string, message: string
   };
 }
 
+describe("spawn overrides", () => {
+  test("caller model/thinking win over inherited values", async () => {
+    process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
+    const parentSessionId = "spawn-overrides";
+    fs.rmSync(path.join(getRunsDir(), parentScopeKey(parentSessionId)), { recursive: true, force: true });
+    const manager = new AgentManager();
+    try {
+      await manager.spawnAgent({ ...spawnParams(parentSessionId, "reviewer", "review"), inheritedThinking: "low", provider: "openai", modelId: "gpt-5", thinking: "xhigh" });
+      expect(manager.getAgentInfo("reviewer", parentSessionId)).toMatchObject({ provider: "openai", modelId: "gpt-5", model: "openai:gpt-5", thinking: "xhigh" });
+      await manager.spawnAgent({ ...spawnParams(parentSessionId, "plain", "work"), inheritedThinking: "low" });
+      expect(manager.getAgentInfo("plain", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "low" });
+      await manager.spawnAgent({ ...spawnParams(parentSessionId, "model-only", "work"), inheritedThinking: "low", provider: "openai", modelId: "gpt-5" });
+      expect(manager.getAgentInfo("model-only", parentSessionId)).toMatchObject({ model: "openai:gpt-5", thinking: "low" });
+      await manager.spawnAgent({ ...spawnParams(parentSessionId, "thinking-only", "work"), inheritedThinking: "low", thinking: "max" });
+      expect(manager.getAgentInfo("thinking-only", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "max" });
+      await expect(manager.spawnAgent({ ...spawnParams(parentSessionId, "half", "work"), provider: "openai" })).rejects.toThrow("needs both provider and modelId");
+    } finally {
+      await manager.shutdown();
+      delete process.env.PI_SUBAGENT_PI_BIN;
+    }
+  });
+
+  test("caller overrides beat a template, and each unset field falls back", async () => {
+    process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
+    const parentSessionId = "spawn-overrides-template";
+    fs.rmSync(path.join(getRunsDir(), parentScopeKey(parentSessionId)), { recursive: true, force: true });
+    const templateFile = path.join(TEST_AGENT_DIR, "pi-codex-subagents", "agents", "routed.md");
+    fs.mkdirSync(path.dirname(templateFile), { recursive: true });
+    fs.writeFileSync(templateFile, "---\nname: routed\nprovider: template-provider\nmodel: template-model\nthinking: medium\n---\nRouted template.");
+    const manager = new AgentManager();
+    const spawn = async (task: string, overrides: Record<string, unknown>) => {
+      await manager.spawnAgent({ ...spawnParams(parentSessionId, task, "work"), agent_type: "routed", inheritedThinking: "low", ...overrides });
+      return manager.getAgentInfo(task, parentSessionId);
+    };
+    try {
+      expect(await spawn("template-wins", {})).toMatchObject({ model: "template-provider:template-model", thinking: "medium" });
+      expect(await spawn("caller-model", { provider: "openai", modelId: "gpt-5" })).toMatchObject({ model: "openai:gpt-5", thinking: "medium" });
+      expect(await spawn("caller-thinking", { thinking: "max" })).toMatchObject({ model: "template-provider:template-model", thinking: "max" });
+      expect(await spawn("caller-both", { provider: "openai", modelId: "gpt-5", thinking: "xhigh" })).toMatchObject({ model: "openai:gpt-5", thinking: "xhigh" });
+      await manager.spawnAgent(spawnParams(parentSessionId, "no-thinking-anywhere", "work"));
+      expect(manager.getAgentInfo("no-thinking-anywhere", parentSessionId)).toMatchObject({ model: "test:fake", thinking: "high" });
+      await expect(manager.spawnAgent({ ...spawnParams(parentSessionId, "missing", "work"), agent_type: "absent" })).rejects.toThrow("Agent template not found");
+    } finally {
+      await manager.shutdown();
+      fs.rmSync(templateFile, { force: true });
+      delete process.env.PI_SUBAGENT_PI_BIN;
+    }
+  });
+});
+
 describe("child process lifecycle", () => {
   test("hibernates after settle and lazily restarts the persisted session", async () => {
     fs.rmSync(path.join(TEST_AGENT_DIR, "pi-codex-subagents", "config.json"), { force: true });
@@ -550,6 +600,12 @@ describe("extension completion delivery and TUI", () => {
       cwd: TEST_AGENT_DIR,
       mode: "tui",
       model: { provider: "test", id: "fake" },
+      modelRegistry: {
+        getAvailable: () => [
+          { provider: "test", id: "fake" },
+          { provider: "fireworks", id: "accounts/fireworks/models/glm-5p2" },
+        ],
+      },
       sessionManager: {
         getSessionId: () => parentSessionId,
         getSessionFile: () => path.join(TEST_AGENT_DIR, "parent.jsonl"),
@@ -600,6 +656,22 @@ describe("extension completion delivery and TUI", () => {
       expect(large.content).toContain("Output truncated");
       expect(large.details.fullOutputPath).toBeString();
       expect(fs.existsSync(large.details.fullOutputPath)).toBe(true);
+
+      await tools.get("spawn_agent").execute("spawn-3", {
+        task_name: "routed",
+        message: "slow finish",
+        model: "fireworks/accounts/fireworks/models/glm-5p2",
+        thinking: "max",
+      }, undefined, undefined, ctx);
+      expect(getAgent("routed", parentSessionId)).toMatchObject({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/models/glm-5p2",
+        thinking: "max",
+      });
+      await expect(tools.get("spawn_agent").execute("spawn-4", { task_name: "unknown-id", message: "x", model: "fireworks/nope" }, undefined, undefined, ctx))
+        .rejects.toThrow("Model ids for fireworks: accounts/fireworks/models/glm-5p2");
+      await expect(tools.get("spawn_agent").execute("spawn-5", { task_name: "unqualified", message: "x", model: "gpt-5" }, undefined, undefined, ctx))
+        .rejects.toThrow('model must be "provider/model-id"');
     } finally {
       await emit("session_shutdown", { reason: "quit" });
       fs.rmSync(scope, { recursive: true, force: true });

--- a/packages/pi-codex-subagents/core.ts
+++ b/packages/pi-codex-subagents/core.ts
@@ -32,6 +32,8 @@ export type AgentRuntimeStatus = "starting" | "running" | "completed" | "failed"
 export interface SubagentConfig {
   storageDir?: string;
   retentionDays?: number;
+  models?: string[];
+  modelsFromEnabledModels?: boolean;
   defaults?: {
     skills?: string[];
     extensions?: string[];
@@ -121,8 +123,7 @@ export interface SpawnAgentParams {
   inheritedModelId: string;
   inheritedThinking?: ThinkingLevel;
   inheritedTools?: string;
-  provider?: string;
-  modelId?: string;
+  model?: { provider: string; modelId: string };
   thinking?: ThinkingLevel;
 }
 
@@ -219,6 +220,8 @@ function normalizeConfig(value: unknown): SubagentConfig {
   return {
     ...(typeof raw.storageDir === "string" && raw.storageDir.trim() ? { storageDir: raw.storageDir.trim() } : {}),
     ...(retentionDays !== undefined ? { retentionDays } : {}),
+    ...(stringList(raw.models) ? { models: stringList(raw.models) } : {}),
+    ...(raw.modelsFromEnabledModels === true ? { modelsFromEnabledModels: true } : {}),
     ...(defaults && Object.keys(defaults).length ? { defaults } : {}),
   };
 }
@@ -469,7 +472,7 @@ export function getAgentDefinition(name?: string): AgentDefinition | undefined {
 
 export function getAgentDefinitionsDescription(): string {
   const definitions = listAgentDefinitions();
-  if (!definitions.length) return `No agent templates found. Add markdown files to ${AGENTS_DIR}.`;
+  if (!definitions.length) return "None configured, so omit `agent_type`.";
   return definitions.map((definition) => {
     let line = `- \`${definition.name}\`${definition.description ? ` — ${definition.description}` : ""}`;
     if (definition.provider && definition.model) line += ` — model: ${definition.provider}/${definition.model}`;
@@ -980,11 +983,8 @@ export class AgentManager {
     const taskName = normalizeTaskName(params.task_name);
     const definition = getAgentDefinition(params.agent_type);
     if (params.agent_type && !definition) throw new Error(`Agent template not found: ${params.agent_type}`);
-    if (Boolean(params.provider) !== Boolean(params.modelId)) throw new Error("Model override needs both provider and modelId.");
-    const callerModel = params.provider && params.modelId;
-    const templateModel = definition?.provider && definition.model;
-    const provider = callerModel ? params.provider! : templateModel ? definition!.provider! : params.inheritedProvider;
-    const modelId = callerModel ? params.modelId! : templateModel ? definition!.model! : params.inheritedModelId;
+    const templateModel = definition?.provider && definition.model ? { provider: definition.provider, modelId: definition.model } : undefined;
+    const { provider, modelId } = params.model ?? templateModel ?? { provider: params.inheritedProvider, modelId: params.inheritedModelId };
     const config = loadSubagentConfig();
     readSystemPrompt();
     const configuredSkills = definition?.skills ?? config.defaults?.skills;

--- a/packages/pi-codex-subagents/core.ts
+++ b/packages/pi-codex-subagents/core.ts
@@ -23,7 +23,7 @@ export const DEFAULT_THINKING = "high";
 export const DEFAULT_TOOLS = "read,bash,grep,find,ls";
 const DEFAULT_SUBAGENT_SYSTEM_PROMPT = "You are a subagent working for a main agent. Work only on the assigned task and follow its scope precisely.";
 
-const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const FINAL_STATUSES = new Set<AgentRuntimeStatus>(["completed", "failed", "interrupted"]);
 
 export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
@@ -121,6 +121,9 @@ export interface SpawnAgentParams {
   inheritedModelId: string;
   inheritedThinking?: ThinkingLevel;
   inheritedTools?: string;
+  provider?: string;
+  modelId?: string;
+  thinking?: ThinkingLevel;
 }
 
 interface PendingRequest {
@@ -977,8 +980,11 @@ export class AgentManager {
     const taskName = normalizeTaskName(params.task_name);
     const definition = getAgentDefinition(params.agent_type);
     if (params.agent_type && !definition) throw new Error(`Agent template not found: ${params.agent_type}`);
-    const provider = definition?.provider && definition.model ? definition.provider : params.inheritedProvider;
-    const modelId = definition?.provider && definition.model ? definition.model : params.inheritedModelId;
+    if (Boolean(params.provider) !== Boolean(params.modelId)) throw new Error("Model override needs both provider and modelId.");
+    const callerModel = params.provider && params.modelId;
+    const templateModel = definition?.provider && definition.model;
+    const provider = callerModel ? params.provider! : templateModel ? definition!.provider! : params.inheritedProvider;
+    const modelId = callerModel ? params.modelId! : templateModel ? definition!.model! : params.inheritedModelId;
     const config = loadSubagentConfig();
     readSystemPrompt();
     const configuredSkills = definition?.skills ?? config.defaults?.skills;
@@ -989,7 +995,7 @@ export class AgentManager {
       : extensions?.length
         ? undefined
         : normalizeTools(params.inheritedTools);
-    const thinking = definition?.thinking ?? params.inheritedThinking ?? DEFAULT_THINKING;
+    const thinking = params.thinking ?? definition?.thinking ?? params.inheritedThinking ?? DEFAULT_THINKING;
     const cwd = path.resolve(params.cwd);
     const directory = scopeDir(params.parentSessionId);
     ensurePrivateDir(directory, true);

--- a/packages/pi-codex-subagents/index.ts
+++ b/packages/pi-codex-subagents/index.ts
@@ -5,11 +5,13 @@ import {
   formatSize,
   truncateHead,
 } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { Text, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import {
   AgentManager,
   getAgentDefinitionsDescription,
+  THINKING_LEVELS,
   type AgentCompletionEvent,
   type AgentInfo,
   type ThinkingLevel,
@@ -79,6 +81,17 @@ export default function (pi: ExtensionAPI) {
   let cachedSkillsSignature = "";
   let activeContext: any;
   const activeAgents = new Set<string>();
+
+  let cachedProviders = "";
+
+  const availableProviders = (registry?: any): string =>
+    [...new Set((registry?.getAvailable?.() ?? []).map((model: any) => model.provider))].join(", ");
+
+  const providerModelIds = (registry: any, provider: string): string[] =>
+    (registry?.getAvailable?.() ?? []).filter((model: any) => model.provider === provider).map((model: any) => model.id);
+
+  const isAvailableModel = (registry: any, provider: string, modelId: string): boolean =>
+    (registry?.getAvailable?.() ?? []).some((model: any) => model.provider === provider && model.id === modelId);
 
   const isCurrentSession = (parentId: string) => {
     try { return activeContext && parentSessionId(activeContext) === parentId; }
@@ -161,8 +174,13 @@ Returns after the child accepts its initial task. Continue with independent work
 
 \`agent_type\` is optional. Omit it for a generic subagent. Use a template only when the task matches it.
 
+\`model\` and \`thinking\` are optional. Both override the template and the parent settings. Use \`model\` when another provider suits the task better, such as an independent review.
+
 Available agent templates:
 ${getAgentDefinitionsDescription()}
+
+Available model providers for \`model\`, written as provider/model-id:
+${cachedProviders || "No providers detected. Omit model to inherit the parent model."}
 
 Available parent skills that may be added by name:
 ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${skill.description}`).join("\n") : "No model-invocable skills are loaded in the parent session."}`;
@@ -172,6 +190,8 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
       message: Type.String({ description: "Initial task for the new agent." }),
       agent_type: Type.Optional(Type.String({ description: "Optional agent template name from ~/.pi/agent/pi-codex-subagents/agents/." })),
       skills: Type.Optional(Type.Array(Type.String(), { description: "Additional skill names from the loaded parent skills listed in this tool description." })),
+      model: Type.Optional(Type.String({ description: "Optional provider/model-id pair such as openai-codex/gpt-5.6-sol. Defaults to the template model, otherwise the parent model." })),
+      thinking: Type.Optional(StringEnum(THINKING_LEVELS, { description: "Optional thinking level. Defaults to the template level, otherwise the parent level." })),
     }),
     async execute(_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any) {
       const currentModel = ctx.model;
@@ -180,6 +200,18 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
       const loadedSkillPaths = Object.fromEntries(cachedSkills.map((skill) => [skill.name, skill.filePath]));
       const unavailableSkills = requestedSkills.filter((skill) => !Object.hasOwn(loadedSkillPaths, skill));
       if (unavailableSkills.length) throw new Error(`spawn_agent failed: skills are not loaded in the parent session: ${unavailableSkills.join(", ")}`);
+      let override: { provider: string; modelId: string } | undefined;
+      if (params.model) {
+        const slash = String(params.model).indexOf("/");
+        if (slash < 1) throw new Error(`spawn_agent failed: model must be "provider/model-id", got "${params.model}".`);
+        const provider = params.model.slice(0, slash);
+        const modelId = params.model.slice(slash + 1);
+        if (!isAvailableModel(ctx.modelRegistry, provider, modelId)) {
+          const known = providerModelIds(ctx.modelRegistry, provider);
+          throw new Error(`spawn_agent failed: unknown model "${params.model}". ${known.length ? `Model ids for ${provider}: ${known.join(", ")}` : `Available providers: ${availableProviders(ctx.modelRegistry) || "none"}`}`);
+        }
+        override = { provider, modelId };
+      }
       try {
         const result = await manager.spawnAgent({
           task_name: params.task_name,
@@ -194,6 +226,8 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
           inheritedModelId: currentModel.id,
           inheritedThinking: pi.getThinkingLevel() as ThinkingLevel,
           inheritedTools: pi.getActiveTools().join(","),
+          ...override,
+          thinking: params.thinking,
         });
         return textResult(`Spawned ${result.task_name}.`, result);
       } catch (error) {
@@ -201,7 +235,7 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
       }
     },
     renderCall(args: any, theme: Theme) {
-      return new Text(theme.fg("toolTitle", theme.bold("spawn_agent ")) + theme.fg("accent", args.task_name || "?") + theme.fg("dim", args.agent_type ? ` [${args.agent_type}]` : ""), 0, 0);
+      return new Text(theme.fg("toolTitle", theme.bold("spawn_agent ")) + theme.fg("accent", args.task_name || "?") + theme.fg("dim", (args.agent_type ? ` [${args.agent_type}]` : "") + (args.model ? ` ${args.model}` : "")), 0, 0);
     },
     renderResult(result: any, _options: any, theme: Theme) {
       if (result.isError) return new Text(theme.fg("error", `✗ ${result.content?.[0]?.text || "failed"}`), 0, 0);
@@ -220,16 +254,18 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
     refreshAgentWidget();
   });
 
-  pi.on("before_agent_start", async (event: any) => {
+  pi.on("before_agent_start", async (event: any, ctx: any) => {
+    const providers = availableProviders(ctx?.modelRegistry);
     const skills = event?.systemPromptOptions?.skills;
     const nextSkills = Array.isArray(skills)
       ? skills
           .filter((skill: any) => !skill?.disableModelInvocation && typeof skill?.name === "string" && typeof skill?.filePath === "string")
           .map((skill: any) => ({ name: skill.name, description: String(skill.description || ""), filePath: skill.filePath }))
       : [];
-    const signature = JSON.stringify(nextSkills);
+    const signature = JSON.stringify([nextSkills, providers]);
     if (signature !== cachedSkillsSignature) {
       cachedSkills = nextSkills;
+      cachedProviders = providers;
       cachedSkillsSignature = signature;
       pi.registerTool(spawnAgentTool);
     }

--- a/packages/pi-codex-subagents/index.ts
+++ b/packages/pi-codex-subagents/index.ts
@@ -11,6 +11,7 @@ import { Text, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works
 import {
   AgentManager,
   getAgentDefinitionsDescription,
+  loadSubagentConfig,
   THINKING_LEVELS,
   type AgentCompletionEvent,
   type AgentInfo,
@@ -82,16 +83,34 @@ export default function (pi: ExtensionAPI) {
   let activeContext: any;
   const activeAgents = new Set<string>();
 
-  let cachedProviders = "";
+  type SpawnModel = { provider: string; modelId: string };
 
-  const availableProviders = (registry?: any): string =>
-    [...new Set((registry?.getAvailable?.() ?? []).map((model: any) => model.provider))].join(", ");
+  const exactPair = (pattern: string): SpawnModel | undefined => {
+    const colon = pattern.lastIndexOf(":");
+    const reference = colon > 0 && (THINKING_LEVELS as readonly string[]).includes(pattern.slice(colon + 1)) ? pattern.slice(0, colon) : pattern;
+    const slash = reference.indexOf("/");
+    if (slash <= 0 || /[*?[\]]/.test(reference)) return undefined;
+    return { provider: reference.slice(0, slash), modelId: reference.slice(slash + 1) };
+  };
 
-  const providerModelIds = (registry: any, provider: string): string[] =>
-    (registry?.getAvailable?.() ?? []).filter((model: any) => model.provider === provider).map((model: any) => model.id);
+  let spawnModels = new Map<string, SpawnModel>();
 
-  const isAvailableModel = (registry: any, provider: string, modelId: string): boolean =>
-    (registry?.getAvailable?.() ?? []).some((model: any) => model.provider === provider && model.id === modelId);
+  const resolveSpawnModels = (ctx: any) => {
+    const config = loadSubagentConfig();
+    const models = new Map<string, SpawnModel>();
+    const available = new Set(ctx.modelRegistry.getAvailable().map((model: any) => `${model.provider}/${model.id}`));
+    const unavailable: string[] = [];
+    for (const entry of config.models ?? []) {
+      const pair = exactPair(entry);
+      if (pair && available.has(`${pair.provider}/${pair.modelId}`)) models.set(`${pair.provider}/${pair.modelId}`, pair);
+      else unavailable.push(entry);
+    }
+    if (config.modelsFromEnabledModels) {
+      for (const { model } of ctx.scopedModels ?? []) models.set(`${model.provider}/${model.id}`, { provider: model.provider, modelId: model.id });
+    }
+    if (unavailable.length) ctx.ui?.notify?.(`spawn_agent models not available: ${unavailable.join(", ")}`, "warning");
+    return models;
+  };
 
   const isCurrentSession = (parentId: string) => {
     try { return activeContext && parentSessionId(activeContext) === parentId; }
@@ -169,30 +188,33 @@ export default function (pi: ExtensionAPI) {
     label: "Spawn Agent",
     get description() {
       return `Spawn a fresh-context Pi subagent for a concrete task. Automatic extension, skill, and prompt-template discovery is disabled. Agent templates may explicitly configure a provider/model pair, thinking level, tools, skills, and extensions. Omitted template settings inherit from the parent where applicable.
-
+${spawnModels.size ? `
+A task may run on a model of its own, without a template: \`model\` takes one of the values its schema lists, and \`thinking\` sets the reasoning effort.
+` : ""}
 Returns after the child accepts its initial task. Continue with independent work instead of waiting; the child's final response will be delivered automatically when ready. Use \`wait_agent\` or \`wait_all_agents\` only when your next action depends on the subagent response and you have no useful work to do meanwhile.
 
 \`agent_type\` is optional. Omit it for a generic subagent. Use a template only when the task matches it.
 
-\`model\` and \`thinking\` are optional. Both override the template and the parent settings. Use \`model\` when another provider suits the task better, such as an independent review.
-
 Available agent templates:
 ${getAgentDefinitionsDescription()}
-
-Available model providers for \`model\`, written as provider/model-id:
-${cachedProviders || "No providers detected. Omit model to inherit the parent model."}
 
 Available parent skills that may be added by name:
 ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${skill.description}`).join("\n") : "No model-invocable skills are loaded in the parent session."}`;
     },
-    parameters: Type.Object({
-      task_name: Type.String({ description: "Task name for the new agent. Use letters, digits, underscores, dashes, and optional slash path separators." }),
-      message: Type.String({ description: "Initial task for the new agent." }),
-      agent_type: Type.Optional(Type.String({ description: "Optional agent template name from ~/.pi/agent/pi-codex-subagents/agents/." })),
-      skills: Type.Optional(Type.Array(Type.String(), { description: "Additional skill names from the loaded parent skills listed in this tool description." })),
-      model: Type.Optional(Type.String({ description: "Optional provider/model-id pair such as openai-codex/gpt-5.6-sol. Defaults to the template model, otherwise the parent model." })),
-      thinking: Type.Optional(StringEnum(THINKING_LEVELS, { description: "Optional thinking level. Defaults to the template level, otherwise the parent level." })),
-    }),
+    get parameters() {
+      return Type.Object({
+        task_name: Type.String({ description: "Task name for the new agent. Use letters, digits, underscores, dashes, and optional slash path separators." }),
+        message: Type.String({ description: "Initial task for the new agent." }),
+        agent_type: Type.Optional(Type.String({ description: "Optional agent template name from ~/.pi/agent/pi-codex-subagents/agents/." })),
+        skills: Type.Optional(Type.Array(Type.String(), { description: "Additional skill names from the loaded parent skills listed in this tool description." })),
+        ...(spawnModels.size
+          ? {
+              model: Type.Optional(StringEnum([...spawnModels.keys()], { description: "Optional model for this one task, for example an independent review by another vendor. Defaults to the template model, otherwise the parent model." })),
+              thinking: Type.Optional(StringEnum(THINKING_LEVELS, { description: "Optional thinking level. Defaults to the template level, otherwise the parent level." })),
+            }
+          : {}),
+      });
+    },
     async execute(_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any) {
       const currentModel = ctx.model;
       if (!currentModel?.provider || !currentModel?.id) throw new Error("spawn_agent failed: the parent has no active provider/model pair.");
@@ -200,17 +222,10 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
       const loadedSkillPaths = Object.fromEntries(cachedSkills.map((skill) => [skill.name, skill.filePath]));
       const unavailableSkills = requestedSkills.filter((skill) => !Object.hasOwn(loadedSkillPaths, skill));
       if (unavailableSkills.length) throw new Error(`spawn_agent failed: skills are not loaded in the parent session: ${unavailableSkills.join(", ")}`);
-      let override: { provider: string; modelId: string } | undefined;
-      if (params.model) {
-        const slash = String(params.model).indexOf("/");
-        if (slash < 1) throw new Error(`spawn_agent failed: model must be "provider/model-id", got "${params.model}".`);
-        const provider = params.model.slice(0, slash);
-        const modelId = params.model.slice(slash + 1);
-        if (!isAvailableModel(ctx.modelRegistry, provider, modelId)) {
-          const known = providerModelIds(ctx.modelRegistry, provider);
-          throw new Error(`spawn_agent failed: unknown model "${params.model}". ${known.length ? `Model ids for ${provider}: ${known.join(", ")}` : `Available providers: ${availableProviders(ctx.modelRegistry) || "none"}`}`);
-        }
-        override = { provider, modelId };
+      const model = params.model ? spawnModels.get(params.model) : undefined;
+      if (params.model && !model) throw new Error(`spawn_agent failed: model "${params.model}" is not in the configured spawn models: ${[...spawnModels.keys()].join(", ") || "none"}`);
+      if (model && !ctx.modelRegistry.getAvailable().some((entry: any) => entry.provider === model.provider && entry.id === model.modelId)) {
+        throw new Error(`spawn_agent failed: model "${params.model}" is not currently available.`);
       }
       try {
         const result = await manager.spawnAgent({
@@ -226,7 +241,7 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
           inheritedModelId: currentModel.id,
           inheritedThinking: pi.getThinkingLevel() as ThinkingLevel,
           inheritedTools: pi.getActiveTools().join(","),
-          ...override,
+          model,
           thinking: params.thinking,
         });
         return textResult(`Spawned ${result.task_name}.`, result);
@@ -246,6 +261,9 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
   pi.on("session_start", async (_event: any, ctx: any) => {
     activeContext = ctx;
     activeAgents.clear();
+    try { spawnModels = resolveSpawnModels(ctx); }
+    catch (error: any) { ctx.ui?.notify?.(`spawn_agent model resolution failed, keeping the previous list: ${error?.message || error}`, "warning"); }
+    pi.registerTool(spawnAgentTool);
     await manager.ready();
     if (activeContext !== ctx) return;
     for (const entry of manager.listAgents(undefined, parentSessionId(ctx))) {
@@ -254,18 +272,16 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
     refreshAgentWidget();
   });
 
-  pi.on("before_agent_start", async (event: any, ctx: any) => {
-    const providers = availableProviders(ctx?.modelRegistry);
+  pi.on("before_agent_start", async (event: any) => {
     const skills = event?.systemPromptOptions?.skills;
     const nextSkills = Array.isArray(skills)
       ? skills
           .filter((skill: any) => !skill?.disableModelInvocation && typeof skill?.name === "string" && typeof skill?.filePath === "string")
           .map((skill: any) => ({ name: skill.name, description: String(skill.description || ""), filePath: skill.filePath }))
       : [];
-    const signature = JSON.stringify([nextSkills, providers]);
+    const signature = JSON.stringify(nextSkills);
     if (signature !== cachedSkillsSignature) {
       cachedSkills = nextSkills;
-      cachedProviders = providers;
       cachedSkillsSignature = signature;
       pi.registerTool(spawnAgentTool);
     }


### PR DESCRIPTION
> Edited after @ogulcancelik's review comment: model selection now comes from an explicit allowlist in `config.json` instead of the parent registry. The original description predates that feedback.

## Summary

A parent session sometimes needs one task on a different model, for example an independent review by another vendor, without authoring a template file. `spawn_agent` gains optional `model` and `thinking` arguments whose selectable values come from an explicit allowlist in the extension's `config.json`, exposed as a `StringEnum` of currently available `provider/model-id` pairs. Installations that configure nothing keep routing in templates and inheritance, with no model wording on the tool.

## User flow

The user lists approved pairs in `~/.pi/agent/pi-codex-subagents/config.json` under `models`, and/or sets `modelsFromEnabledModels: true` to reuse the models pi already scoped for the session. From the next session on, the spawn tool offers `model` and `thinking`; the parent picks one per spawn and the child runs on that pair. Allowlist entries that are not currently available surface as a warning notification and stay out of the enum. A model that drops out mid-session is refused at spawn time with a clear error.

## Behavior changes

| | Before | After |
|---|---|---|
| `spawn_agent` parameters | `task_name`, `message`, `agent_type`, `skills` | plus optional `model` and `thinking` when at least one allowed model is available |
| Model resolution | template, then inherited parent model | caller, then template, then inherited, then default |
| Unconfigured installation | n/a | unchanged behavior, no model parameter or wording |
| Empty template list in the tool description | "No agent templates found. Add markdown files to ..." | "None configured, so omit `agent_type`." |

## Implementation notes

- `config.json` gains `models` (exact `provider/model-id` pairs) and `modelsFromEnabledModels` (boolean).
- One resolution point, at `session_start`: `models` entries are filtered against `modelRegistry.getAvailable()`, unioned with `ctx.scopedModels` pairs, and the tool is re-registered because pi snapshots tool schemas at wrap time.
- `description` and `parameters` are getters, so re-registration picks up current state; `model` and `thinking` gate together.
- `execute` validates enum membership and rechecks availability at spawn time.
- The caller pair travels as one `{provider, modelId}` object through `SpawnAgentParams`, so a partial pair is unrepresentable.

## Design decisions

- Explicit allowlist instead of the parent registry (review feedback): users approve exact runtime routes without exposing every authenticated provider.
- `ctx.scopedModels` instead of re-resolving `settings.json`: pi has already expanded globs, preferred aliases, and applied availability and auth checks, and the scope includes `--models` narrowing; the extension carries no duplicate resolution logic.
- No globs in `models`: exact pairs keep resolution to a set lookup; pattern power remains available through the `enabledModels` source, resolved by pi itself.
- One resolution point instead of per-turn re-resolution: config edits apply on the next session, consistent with the documented `storageDir`/`retentionDays` behavior, and the spawn-time recheck covers mid-session drift.

## Data and rollout

No storage or migration impact; both config keys are optional and absent config preserves existing behavior. Extension-registered providers remain unsupported except through templates that load the provider extension, since children load no extensions of their own.

## Risks and edge cases

- A provider dropping out mid-session leaves a stale enum until the next session; `execute` refuses such a model with "not currently available".
- `modelsFromEnabledModels` with no pi scoping configured contributes nothing; it never means "all available models".
- A thinking level the child model does not support is clamped by the child.
- A thinking suffix on an allowlist entry (`provider/model:high`) is tolerated and stripped; `thinking` stays a separate argument.

## Tests

- core: resolution order caller > template > inherited > default, thinking fallback to the package default, unknown template rejection.
- extension integration: gating on and off via config, enum content (available allowlist entries unioned with scoped models), unavailable-entry notification, spawn routing with a thinking override verified against the run record, refusal of non-allowlisted models, refusal of allowlisted models that lost availability mid-session.

21 tests, 109 expects, all passing.
