### PR TITLE
fix(pi-herdr): accept silent pane submissions

### DIFF
--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -60,7 +60,7 @@ Use `herdr_pane` for ordinary commands and intentional raw terminal control.
 | Action | Description |
 |---|---|
 | `get` | Inspect a pane |
-| `run` | Submit a shell command atomically with Enter |
+| `run` | Submit a shell command atomically with Enter and report the submission acknowledgement, not the command exit code |
 | `read` | Read terminal output |
 | `wait_output` | Wait for literal or regular-expression output |
 | `send_text` | Send literal text without Enter |
@@ -68,6 +68,10 @@ Use `herdr_pane` for ordinary commands and intentional raw terminal control.
 | `close` | Close a pane other than the pane running Pi |
 
 `wait_output` searches existing output immediately before waiting for future output. Use `recent-unwrapped` for logs and transcripts.
+
+`run` invokes the Herdr client exactly once. A zero client exit means the server accepted the submission even when the client's stdout is empty; pane prompts, banners, ANSI, and command output are never parsed as protocol JSON. The successful tool result records `submissionStatus: "accepted"`, `commandStatus: "not_observed"`, and `commandExitCode: null`. Capture the target command's actual exit code in a unique pane-output marker, then inspect it with `wait_output` or `read`.
+
+A nonzero Herdr client exit with a structured Herdr error is reported as a failed submission. A killed client or nonzero exit without a structured error is reported as ambiguous because the command may already have been accepted; the extension never retries automatically.
 
 Pane actions do not validate coding-agent identity or interpret agent lifecycle. Use `herdr_agent` when a pane contains a recognized coding agent.
 

--- a/packages/pi-herdr/index.test.ts
+++ b/packages/pi-herdr/index.test.ts
@@ -33,20 +33,24 @@ function response(result: unknown, stdout?: string) {
 	};
 }
 
-function registerTools(handler: (args: string[]) => unknown | string) {
+function registerToolsWithExec(exec: (command: string, args: string[]) => Promise<any>) {
 	const tools = new Map<string, any>();
 	const pi = {
 		registerTool(definition: any) {
 			tools.set(definition.name, definition);
 		},
-		async exec(command: string, args: string[]) {
-			expect(command).toBe("herdr");
-			const result = handler(args);
-			return typeof result === "string" ? response(undefined, result) : response(result);
-		},
+		exec,
 	};
 	herdrExtension(pi as any);
 	return tools;
+}
+
+function registerTools(handler: (args: string[]) => unknown | string) {
+	return registerToolsWithExec(async (command, args) => {
+		expect(command).toBe("herdr");
+		const result = handler(args);
+		return typeof result === "string" ? response(undefined, result) : response(result);
+	});
 }
 
 beforeEach(() => {
@@ -142,6 +146,192 @@ describe("pi-herdr", () => {
 
 		expect(calls).toEqual([["pane", "wait-output", "w1:p2", "--match", "ready", "--timeout", "30000"]]);
 		expect(result.content[0].text).toContain("server ready");
+	});
+
+	test("submits a silent pane command exactly once and separates command status", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (command, args) => {
+			expect(command).toBe("herdr");
+			calls.push(args);
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		});
+
+		const result = await tools.get("herdr_pane").execute(
+			"test",
+			{ action: "run", pane: "w1:p2", command: ":" },
+			undefined,
+			undefined,
+			{},
+		);
+
+		expect(calls).toEqual([["pane", "run", "w1:p2", ":"]]);
+		expect(result.content[0].text).toContain("submission accepted");
+		expect(result.details).toEqual({
+			action: "run",
+			pane: "w1:p2",
+			command: ":",
+			submissionStatus: "accepted",
+			commandStatus: "not_observed",
+			commandExitCode: null,
+		});
+	});
+
+	test("keeps a confirmed code-zero submission accepted when cancellation races after completion", async () => {
+		const controller = new AbortController();
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			controller.abort();
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		});
+
+		const result = await tools.get("herdr_pane").execute(
+			"test",
+			{ action: "run", pane: "w1:p2", command: ":" },
+			controller.signal,
+			undefined,
+			{},
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(result.details.submissionStatus).toBe("accepted");
+	});
+
+	test("does not parse pane banners, ANSI, or stderr as run protocol JSON", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			return {
+				stdout: "\u001b[31mstartup banner\u001b[0m\n{not-json}\n",
+				stderr: "shell warning that is not protocol output\n",
+				code: 0,
+				killed: false,
+			};
+		});
+
+		const result = await tools.get("herdr_pane").execute(
+			"test",
+			{ action: "run", pane: "w1:p2", command: "printf done" },
+			undefined,
+			undefined,
+			{},
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(result.details.submissionStatus).toBe("accepted");
+		expect(result.details.commandStatus).toBe("not_observed");
+	});
+
+	test("does not treat JSON-shaped code-zero stdout as a submission error", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			return {
+				stdout: `${JSON.stringify({ error: { code: "not_protocol", message: "pane banner data" } })}\n`,
+				stderr: "",
+				code: 0,
+				killed: false,
+			};
+		});
+
+		const result = await tools.get("herdr_pane").execute(
+			"test",
+			{ action: "run", pane: "w1:p2", command: ":" },
+			undefined,
+			undefined,
+			{},
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(result.details.submissionStatus).toBe("accepted");
+	});
+
+	test("reports an explicit Herdr rejection as a failed submission without retry", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			return {
+				stdout: "",
+				stderr: `${JSON.stringify({ error: { code: "pane_not_found", message: "pane w1:p2 not found" } })}\n`,
+				code: 1,
+				killed: false,
+			};
+		});
+
+		expect(
+			tools.get("herdr_pane").execute(
+				"test",
+				{ action: "run", pane: "w1:p2", command: "printf must-not-run" },
+				undefined,
+				undefined,
+				{},
+			),
+		).rejects.toThrow("Pane command submission failed (pane_not_found): pane w1:p2 not found");
+		expect(calls).toHaveLength(1);
+	});
+
+	test("reports an unstructured client failure as ambiguous without retry", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			return {
+				stdout: "",
+				stderr: "socket closed after request write",
+				code: 1,
+				killed: false,
+			};
+		});
+
+		expect(
+			tools.get("herdr_pane").execute(
+				"test",
+				{ action: "run", pane: "w1:p2", command: "printf maybe-ran" },
+				undefined,
+				undefined,
+				{},
+			),
+		).rejects.toThrow(/submission outcome is ambiguous.*do not retry automatically/i);
+		expect(calls).toHaveLength(1);
+	});
+
+	test("reports a killed Herdr client as ambiguous without retry", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			return { stdout: "", stderr: "", code: 0, killed: true };
+		});
+
+		expect(
+			tools.get("herdr_pane").execute(
+				"test",
+				{ action: "run", pane: "w1:p2", command: "printf maybe-ran" },
+				undefined,
+				undefined,
+				{},
+			),
+		).rejects.toThrow(/submission outcome is ambiguous.*do not retry automatically/i);
+		expect(calls).toHaveLength(1);
+	});
+
+	test("does not confuse a target command exit with submission acknowledgement", async () => {
+		const calls: string[][] = [];
+		const tools = registerToolsWithExec(async (_command, args) => {
+			calls.push(args);
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		});
+
+		const result = await tools.get("herdr_pane").execute(
+			"test",
+			{ action: "run", pane: "w1:p2", command: "sh -c 'exit 7'" },
+			undefined,
+			undefined,
+			{},
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(result.details.submissionStatus).toBe("accepted");
+		expect(result.details.commandStatus).toBe("not_observed");
+		expect(result.details.commandExitCode).toBeNull();
 	});
 
 	test("refuses to close the caller pane", async () => {

--- a/packages/pi-herdr/index.ts
+++ b/packages/pi-herdr/index.ts
@@ -117,15 +117,31 @@ const AgentKindEnum = StringEnum(
 	{ description: "Supported coding agent kind and canonical executable" },
 );
 
-function parseHerdrError(output: string): string | null {
+function parseHerdrErrorEnvelope(output: string): HerdrJsonEnvelope["error"] | null {
 	const trimmed = output.trim();
 	if (!trimmed) return null;
 	try {
 		const value = JSON.parse(trimmed) as HerdrJsonEnvelope;
-		return value.error?.message || value.error?.code || trimmed;
+		if (!value.error || typeof value.error !== "object") return null;
+		const code = typeof value.error.code === "string" ? value.error.code : undefined;
+		const message = typeof value.error.message === "string" ? value.error.message : undefined;
+		return code || message ? { code, message } : null;
 	} catch {
-		return trimmed;
+		return null;
 	}
+}
+
+function parseHerdrError(output: string): string | null {
+	const trimmed = output.trim();
+	if (!trimmed) return null;
+	const error = parseHerdrErrorEnvelope(trimmed);
+	return error?.message || error?.code || trimmed;
+}
+
+function formatTransportDiagnostic(output: string): string {
+	const trimmed = output.trim();
+	if (!trimmed) return "";
+	return truncateTail(trimmed, { maxLines: 20, maxBytes: 2048 }).content.trim();
 }
 
 function isAbortError(error: unknown, signal?: AbortSignal): boolean {
@@ -286,6 +302,27 @@ export default function (pi: ExtensionAPI) {
 
 	async function execHerdrText(args: string[], signal?: AbortSignal): Promise<string> {
 		return (await execHerdr(args, signal)).stdout;
+	}
+
+	async function submitPaneCommand(paneId: string, command: string, signal?: AbortSignal): Promise<void> {
+		const result = await pi.exec("herdr", ["pane", "run", paneId, command], { signal });
+		if (!result.killed && result.code === 0) return;
+
+		const rejection = parseHerdrErrorEnvelope(result.stderr) || parseHerdrErrorEnvelope(result.stdout);
+		if (rejection) {
+			const code = rejection.code ? ` (${rejection.code})` : "";
+			const message = rejection.message || rejection.code || "Herdr rejected the request";
+			throw new Error(`Pane command submission failed${code}: ${message}`);
+		}
+
+		const reason = result.killed || signal?.aborted
+			? "the Herdr client was cancelled or killed before a conclusive acknowledgement"
+			: `the Herdr client exited with code ${result.code} without a structured Herdr error`;
+		const diagnostic = formatTransportDiagnostic(result.stderr || result.stdout);
+		throw new Error(
+			`Pane command submission outcome is ambiguous: ${reason}${diagnostic ? `; client output: ${diagnostic}` : ""}. `
+			+ "The command may have been accepted; do not retry automatically.",
+		);
 	}
 
 	async function getCurrentPane(signal?: AbortSignal): Promise<PaneInfo> {
@@ -504,10 +541,20 @@ export default function (pi: ExtensionAPI) {
 				}
 				case "run": {
 					if (!params.command) throw new Error("'command' is required for run");
-					await execHerdrJson(["pane", "run", params.pane, params.command], signal);
+					await submitPaneCommand(params.pane, params.command, signal);
 					return {
-						content: [{ type: "text", text: `Submitted command to pane ${params.pane}` }],
-						details: { action: "run", pane: params.pane, command: params.command },
+						content: [{
+							type: "text",
+							text: `Submitted command to pane ${params.pane}; submission accepted, command exit status not observed.`,
+						}],
+						details: {
+							action: "run",
+							pane: params.pane,
+							command: params.command,
+							submissionStatus: "accepted",
+							commandStatus: "not_observed",
+							commandExitCode: null,
+						},
 					};
 				}
 				case "read": {


### PR DESCRIPTION
## Summary

- treat a zero `herdr pane run` client exit as an accepted submission even when stdout is empty
- keep submission acknowledgement separate from the target command's unobserved exit status
- distinguish explicit Herdr rejections from ambiguous killed or unstructured client failures without retrying
- document the exactly-once and marker-based observation contract

## Root cause

Herdr 0.8.0 handles `pane run` through `send_ok_request`, which exits successfully without emitting JSON. The adapter used the JSON-response helper for this action, so it reported `Expected JSON output` after the command had already been submitted and executed.

## Validation

- `npm exec --yes --package=bun@1.3.14 -- npm test --workspace @ogulcancelik/pi-herdr` — 17 passed
- TypeScript 7.0.2 `tsc --noEmit` on `packages/pi-herdr/index.ts`
- `npm pack --dry-run`
- `git diff --check`
- live Herdr matrix covering silent commands, stdout/stderr, target exit 7, long quoting, and ANSI/banner output; every case executed exactly once and reported submission acceptance independently of the target exit

## Notes

This PR does not change the package version or publish the package.
