### PR TITLE
fix(codex-compaction): normalize overlong call ids

### DIFF
--- a/packages/pi-codex-compaction/index.test.ts
+++ b/packages/pi-codex-compaction/index.test.ts
@@ -630,6 +630,89 @@ describe("native compaction helpers", () => {
 		});
 	});
 
+	test("preserves valid call ids and keeps hashed shared prefixes distinct", () => {
+		// pi-cursor-sdk bridge ids reach 64 characters at tool 1 and exceed the
+		// Responses API limit once the tool index gains a second digit.
+		const runId = "cursor-pi-bridge-run-00000000-0000-4000-8000-000000000000-tool-";
+		const callIds = [`${runId}1`, `${runId}10`, `${runId}11`];
+		expect(callIds.map((id) => id.length)).toEqual([64, 65, 65]);
+		const assistant = {
+			type: "message",
+			id: "assistant-long-tools",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			message: {
+				role: "assistant",
+				content: callIds.map((id, index) => ({
+					type: "toolCall",
+					id: `${id}|fc_item_${index}`,
+					name: "edit",
+					arguments: {},
+				})),
+				provider: "openai-codex",
+				api: "openai-codex-responses",
+				model: model.id,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			},
+		} as SessionEntry;
+		const toolResults = callIds.map((callId, index) => ({
+			type: "message",
+			id: `tool-result-${index}`,
+			parentId: index === 0 ? "assistant-long-tools" : `tool-result-${index - 1}`,
+			timestamp: new Date().toISOString(),
+			message: {
+				role: "toolResult",
+				toolCallId: `${callId}|fc_item_${index}`,
+				toolName: "edit",
+				content: [{ type: "text", text: `ok-${index}` }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		}) as SessionEntry);
+
+		const input = effectiveInputForBranch({ branch: [assistant, ...toolResults], model, tools: [] });
+		const calls = input.filter((item) => item.type === "function_call");
+		const outputs = input.filter((item) => item.type === "function_call_output");
+		const normalizedIds = calls.map((item) => String(item.call_id));
+		expect(normalizedIds[0]).toBe(callIds[0]);
+		expect(normalizedIds.slice(1)).not.toEqual(callIds.slice(1));
+		expect(calls.map((item) => item.id)).toEqual(["fc_item_0", "fc_item_1", "fc_item_2"]);
+		expect(normalizedIds.every((id) => id.length <= 64)).toBe(true);
+		expect(new Set(normalizedIds).size).toBe(normalizedIds.length);
+		expect(outputs.map((item) => item.call_id)).toEqual(normalizedIds);
+	});
+
+	test("synthesized outputs for orphaned over-limit call ids stay paired", () => {
+		const longCallId = `cursor-pi-bridge-run-${"1".repeat(36)}-tool-11`;
+		const assistant = {
+			type: "message",
+			id: "assistant-long-orphan",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: `${longCallId}|fc_item_2`, name: "edit", arguments: {} }],
+				provider: "openai-codex",
+				api: "openai-codex-responses",
+				model: model.id,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			},
+		} as SessionEntry;
+		const user = { ...userEntry("user-after-long-orphan", "interrupt"), parentId: "assistant-long-orphan" } as SessionEntry;
+
+		const input = effectiveInputForBranch({ branch: [assistant, user], model, tools: [] });
+		const call = input.find((item) => item.type === "function_call")!;
+		const output = input.find((item) => item.type === "function_call_output")!;
+		expect(String(call.call_id).length).toBeLessThanOrEqual(64);
+		expect(output).toEqual({
+			type: "function_call_output",
+			call_id: call.call_id,
+			output: "No result provided",
+		});
+	});
+
 	test("latest compaction on the active branch is authoritative", () => {
 		const native = {
 			type: "compaction",

--- a/packages/pi-codex-compaction/native-compaction.ts
+++ b/packages/pi-codex-compaction/native-compaction.ts
@@ -127,6 +127,14 @@ function normalizedItemId(value: string | undefined): string | undefined {
 	return sanitized.startsWith("fc_") ? sanitized : `fc_${sanitized}`.slice(0, 64);
 }
 
+// The Responses API rejects call_ids longer than 64 characters. Hashing avoids
+// the deterministic prefix collisions caused by truncation, and the stable
+// mapping keeps function_call/function_call_output pairs matched since both
+// sides derive from the same source id.
+function normalizedCallId(value: string): string {
+	return value.length <= 64 ? value : `call_${shortHash(value)}`;
+}
+
 function textSignature(value: unknown): { id?: string; phase?: "commentary" | "final_answer" } {
 	if (typeof value !== "string" || !value) return {};
 	try {
@@ -235,7 +243,8 @@ function messagesToResponseItems(model: Model<any>, messages: Message[], tools: 
 					continue;
 				}
 				if (block.type === "toolCall" && typeof block.id === "string") {
-					const [callId, rawItemId] = block.id.split("|");
+					const [rawCallId, rawItemId] = block.id.split("|");
+					const callId = normalizedCallId(rawCallId);
 					pendingToolCalls.set(block.id, callId);
 					items.push({
 						type: "function_call",
@@ -247,7 +256,8 @@ function messagesToResponseItems(model: Model<any>, messages: Message[], tools: 
 				}
 			}
 		} else if (message.role === "toolResult" && typeof message.toolCallId === "string") {
-			const [callId] = message.toolCallId.split("|");
+			const [rawCallId] = message.toolCallId.split("|");
+			const callId = normalizedCallId(rawCallId);
 			pendingToolCalls.delete(message.toolCallId);
 			items.push({ type: "function_call_output", call_id: callId, output: toolResultOutput(message, model) });
 


### PR DESCRIPTION
# Fix Codex compaction for over-limit Cursor SDK call IDs

## Summary

This fixes native Codex compaction failures triggered by tool call IDs generated by `pi-cursor-sdk`.

## Root Cause

`pi-cursor-sdk` generates tool call IDs in this format:

```text
cursor-pi-bridge-run-<uuid>-tool-<index>
```

A single-digit tool index produces a 64-character ID, but IDs such as `tool-10` are 65 characters long.

During native compaction, `pi-codex-compaction` replayed these IDs unchanged as OpenAI Responses API `call_id` values. Since the API limits `call_id` to 64 characters, compaction failed with:

```text
Invalid 'input[N].call_id': string too long.
Expected a string with maximum length 64.
```

## Fix

- Preserve valid `call_id` values up to 64 characters.
- Deterministically hash over-limit IDs instead of truncating them.
- Apply the same mapping to `function_call`, `function_call_output`, and synthesized orphan outputs so pairing remains intact.
- Hashing avoids the prefix collisions that simple truncation could cause between IDs such as `tool-1` and `tool-10`.

## Validation

- Added coverage for 64- and 65-character Cursor SDK IDs.
- Verified multiple IDs sharing the same prefix remain distinct.
- Verified normal and synthesized outputs remain correctly paired.
- Replayed the original failing session locally with no over-limit, duplicate, missing, or orphaned `call_id` values.
- All 22 tests pass.
