### PR TITLE
fix(model-thinking): support max thinking level

### DIFF
--- a/packages/pi-model-thinking/index.ts
+++ b/packages/pi-model-thinking/index.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 const CONFIG_FILENAME = "model-thinking.json";
 
-const ALL_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const ALL_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 type ThinkingLevel = (typeof ALL_LEVELS)[number];
 
 interface ModelThinkingConfig {


### PR DESCRIPTION
Pi now supports the `max` thinking level, but `pi-model-thinking`'s allowlist stopped at `xhigh`. This caused `max` values in `model-thinking.json` to be discarded during config normalization.

Add `max` to the accepted thinking levels so model- and provider-level settings are applied correctly.