### PR TITLE
fix(auto-permissions): release completed tool-row invalidators

### DIFF
--- a/packages/pi-auto-permissions/index.test.ts
+++ b/packages/pi-auto-permissions/index.test.ts
@@ -706,12 +706,95 @@ describe("auto permissions tool gate", () => {
       stopReason: "stop",
     });
     expect(await pending).toBeUndefined();
+    const terminalInvalidations = invalidations;
     expect(render()).toContain("approved");
     expect(render()).toContain("authorized");
     await Bun.sleep(1);
     expect(render()).toContain("approved");
     expect(harnessState.widgets).toHaveLength(0);
     await harnessState.sessionShutdownHandler({}, harnessState.ctx);
+    expect(invalidations).toBe(terminalInvalidations);
+  });
+
+  test("releases tool-row invalidators after requesting revision", async () => {
+    useToolRowConfig();
+    reviewerText = '{"decision":"revise","reason":"use a feature branch"}';
+    const state = harness(["push this branch"], "tui");
+    await state.sessionStartHandler({}, state.ctx);
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
+    let invalidations = 0;
+    let lastComponent: any;
+    const renderState = {};
+    const render = () => {
+      lastComponent = state.bashTool.renderCall(
+        { command: "git push origin feature" },
+        theme,
+        {
+          state: renderState,
+          toolCallId: "call-revise",
+          invalidate: () => { invalidations++; },
+          lastComponent,
+          executionStarted: true,
+        },
+      );
+      return lastComponent.render(120).join("\n");
+    };
+
+    render();
+    const result = await state.toolCallHandler(
+      { toolName: "bash", toolCallId: "call-revise", input: { command: "git push origin feature" } },
+      state.ctx,
+    );
+    expect(result.reason).toContain("use a feature branch");
+    const terminalInvalidations = invalidations;
+    expect(render()).toContain("revision requested");
+    expect(render()).toContain("use a feature branch");
+    await state.sessionShutdownHandler({}, state.ctx);
+    expect(invalidations).toBe(terminalInvalidations);
+  });
+
+  test("retains ask-user invalidation until the blocked terminal transition", async () => {
+    useToolRowConfig();
+    reviewerText = '{"decision":"ask_user","reason":"approval was not explicit"}';
+    const state = harness(["check whether this can be pushed"], "tui");
+    await state.sessionStartHandler({}, state.ctx);
+    let resolveSelect!: (value: string) => void;
+    (state.ctx.ui as any).select = () => new Promise((resolve) => { resolveSelect = resolve; });
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
+    let invalidations = 0;
+    let lastComponent: any;
+    const renderState = {};
+    const render = () => {
+      lastComponent = state.bashTool.renderCall(
+        { command: "git push origin feature" },
+        theme,
+        {
+          state: renderState,
+          toolCallId: "call-ask-user",
+          invalidate: () => { invalidations++; },
+          lastComponent,
+          executionStarted: true,
+        },
+      );
+      return lastComponent.render(120).join("\n");
+    };
+
+    render();
+    const pending = state.toolCallHandler(
+      { toolName: "bash", toolCallId: "call-ask-user", input: { command: "git push origin feature" } },
+      state.ctx,
+    );
+    await Bun.sleep(0);
+    expect(render()).toContain("approval required");
+    const askUserInvalidations = invalidations;
+    resolveSelect("Block");
+    expect(await pending).toEqual({ block: true, reason: "Blocked by user" });
+    expect(invalidations).toBeGreaterThan(askUserInvalidations);
+    const terminalInvalidations = invalidations;
+    expect(render()).toContain("blocked");
+    expect(render()).toContain("blocked by user");
+    await state.sessionShutdownHandler({}, state.ctx);
+    expect(invalidations).toBe(terminalInvalidations);
   });
 
   test("falls back to the widget if another extension replaces bash later", async () => {

--- a/packages/pi-auto-permissions/index.test.ts
+++ b/packages/pi-auto-permissions/index.test.ts
@@ -685,6 +685,7 @@ describe("auto permissions tool gate", () => {
           invalidate: () => { invalidations++; },
           lastComponent,
           executionStarted: true,
+          isPartial: true,
         },
       );
       return (lastComponent as { render(width: number): string[] }).render(120).join("\n");
@@ -735,6 +736,7 @@ describe("auto permissions tool gate", () => {
           invalidate: () => { invalidations++; },
           lastComponent,
           executionStarted: true,
+          isPartial: true,
         },
       );
       return lastComponent.render(120).join("\n");
@@ -774,6 +776,7 @@ describe("auto permissions tool gate", () => {
           invalidate: () => { invalidations++; },
           lastComponent,
           executionStarted: true,
+          isPartial: true,
         },
       );
       return lastComponent.render(120).join("\n");
@@ -811,22 +814,36 @@ describe("auto permissions tool gate", () => {
     expect(harnessState.widgets).toHaveLength(2);
   });
 
-  test("releases unguarded bash row invalidators when execution ends", async () => {
+  test("does not re-register unguarded bash row invalidators after execution ends", async () => {
     useToolRowConfig();
     const harnessState = harness([], "tui");
     await harnessState.sessionStartHandler({}, harnessState.ctx);
     let invalidations = 0;
+    const state = {};
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
     harnessState.bashTool.renderCall(
       { command: "echo safe" },
-      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+      theme,
       {
-        state: {},
+        state,
         toolCallId: "call-safe",
         invalidate: () => { invalidations++; },
         executionStarted: true,
+        isPartial: true,
       },
     );
     await harnessState.toolExecutionEndHandler({ toolName: "bash", toolCallId: "call-safe" });
+    harnessState.bashTool.renderCall(
+      { command: "echo safe" },
+      theme,
+      {
+        state,
+        toolCallId: "call-safe",
+        invalidate: () => { invalidations++; },
+        executionStarted: true,
+        isPartial: false,
+      },
+    );
     await harnessState.sessionShutdownHandler({}, harnessState.ctx);
     expect(invalidations).toBe(0);
   });

--- a/packages/pi-auto-permissions/index.ts
+++ b/packages/pi-auto-permissions/index.ts
@@ -22,6 +22,11 @@ const PROJECT_CONFIG_DIR_NAME = (PiCodingAgent as { CONFIG_DIR_NAME?: string }).
 
 type BlockResult = { block: true; reason: string };
 type ReviewDisplayState = "waiting" | "approved" | "revise" | "ask_user" | "blocked";
+
+function isTerminalReviewState(state: ReviewDisplayState): boolean {
+  return state === "approved" || state === "revise" || state === "blocked";
+}
+
 type ReviewTarget = { toolName: string; toolCallId?: string };
 type ReviewRow = {
   gate: Gate;
@@ -411,11 +416,15 @@ export default function autoPermissionsExtension(pi: ExtensionAPI) {
           lastComponent: state.autoPermissionsBaseCallComponent,
         });
         state.autoPermissionsBaseCallComponent = base;
-        reviewRowInvalidators.set(context.toolCallId, context.invalidate);
+        const review = reviewRows.get(context.toolCallId);
+        if (!review || !isTerminalReviewState(review.state)) {
+          reviewRowInvalidators.set(context.toolCallId, context.invalidate);
+        } else {
+          reviewRowInvalidators.delete(context.toolCallId);
+        }
 
         const container = new Container();
         container.addChild(base);
-        const review = reviewRows.get(context.toolCallId);
         if (review) {
           const status = review.state === "waiting"
             ? theme.fg("warning", "◌ guardian running")
@@ -476,7 +485,16 @@ export default function autoPermissionsExtension(pi: ExtensionAPI) {
 
     if (target.toolName === "bash" && target.toolCallId && ownsBashRenderer()) {
       reviewRows.set(target.toolCallId, { gate, state, reviewer, detail });
-      reviewRowInvalidators.get(target.toolCallId)?.();
+      const invalidate = reviewRowInvalidators.get(target.toolCallId);
+      if (isTerminalReviewState(state)) {
+        try {
+          invalidate?.();
+        } finally {
+          reviewRowInvalidators.delete(target.toolCallId);
+        }
+      } else {
+        invalidate?.();
+      }
       return;
     }
 
@@ -634,7 +652,7 @@ export default function autoPermissionsExtension(pi: ExtensionAPI) {
 
   pi.on("tool_execution_end", async (event) => {
     if (event.toolName !== "bash") return;
-    if (!reviewRows.has(event.toolCallId)) reviewRowInvalidators.delete(event.toolCallId);
+    reviewRowInvalidators.delete(event.toolCallId);
   });
 
   pi.registerTool({

--- a/packages/pi-auto-permissions/index.ts
+++ b/packages/pi-auto-permissions/index.ts
@@ -417,7 +417,8 @@ export default function autoPermissionsExtension(pi: ExtensionAPI) {
         });
         state.autoPermissionsBaseCallComponent = base;
         const review = reviewRows.get(context.toolCallId);
-        if (!review || !isTerminalReviewState(review.state)) {
+        const canStillChange = context.isPartial && (!review || !isTerminalReviewState(review.state));
+        if (canStillChange) {
           reviewRowInvalidators.set(context.toolCallId, context.invalidate);
         } else {
           reviewRowInvalidators.delete(context.toolCallId);


### PR DESCRIPTION
## Summary

- retain tool-row invalidators only while review state can still change
- perform the final redraw and release callbacks on `approved`, `revise`, and `blocked` transitions
- prevent historical rerenders of terminal rows from registering callbacks again
- delete callbacks defensively when bash execution ends while preserving terminal review-row state

## Why

The tool-row renderer stores `context.invalidate` so asynchronous review transitions can redraw the row. Once a review reaches a terminal state, retaining that callback also retains the completed row's renderer/component graph until session shutdown. Historical or expanded rerenders could previously reinsert the callback after completion.

This is a long-session resource-retention issue, not a permission bypass. The retained memory depends on session length, guarded-command count, and renderer state size.

## Testing

- `bun test packages/pi-auto-permissions`
- covered approved, revision, ask-user-to-block, terminal rerender, and unguarded execution-end cleanup paths
