### PR TITLE
fix(subagents): don't hang forever when two managers try to write to the same persisted run

### DIFF
--- a/packages/pi-codex-subagents/core.test.ts
+++ b/packages/pi-codex-subagents/core.test.ts
@@ -550,6 +550,90 @@ describe("completion delivery", () => {
     }
   });
 
+  test("delivers an externally persisted terminal state to an active waiter exactly once", async () => {
+    process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
+    const parentSessionId = "completion-external-terminal";
+    const scope = path.join(getRunsDir(), parentScopeKey(parentSessionId));
+    fs.rmSync(scope, { recursive: true, force: true });
+    const completions: any[] = [];
+    const manager = new AgentManager({ onUnclaimedCompletion: (event: any) => completions.push(event) });
+    try {
+      await manager.spawnAgent(spawnParams(parentSessionId, "worker", "hold external"));
+      const wait = manager.waitAgent(parentSessionId, ["worker"]);
+      const persisted = manager.getAgentInfo("worker", parentSessionId);
+      persisted.status = "interrupted";
+      persisted.lastActivity = Date.now();
+      fs.writeFileSync(persisted.infoFile, JSON.stringify(persisted, null, 2));
+
+      // Force terminal-state observation through stdin failure before process exit.
+      const live = (manager as any).live.get(persisted.id);
+      live.proc.stdin.emit("error", new Error("forced stdin race"));
+      expect((await wait).event).toMatchObject({ agentName: "/worker", status: "interrupted" });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(completions).toEqual([]);
+    } finally {
+      await manager.shutdown();
+      fs.rmSync(scope, { recursive: true, force: true });
+      delete process.env.PI_SUBAGENT_PI_BIN;
+    }
+  });
+
+  test("delivers an adopted terminal state observed through child output to wait_all_agents", async () => {
+    process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
+    const parentSessionId = "completion-external-output";
+    const scope = path.join(getRunsDir(), parentScopeKey(parentSessionId));
+    fs.rmSync(scope, { recursive: true, force: true });
+    const completions: any[] = [];
+    const manager = new AgentManager({ onUnclaimedCompletion: (event: any) => completions.push(event) });
+    try {
+      await manager.spawnAgent(spawnParams(parentSessionId, "worker", "hold external"));
+      const wait = manager.waitAllAgents(parentSessionId, ["worker"]);
+      const persisted = manager.getAgentInfo("worker", parentSessionId);
+      persisted.status = "completed";
+      persisted.finalResponse = "persisted response";
+      persisted.completedAt = Date.now();
+      fs.writeFileSync(persisted.infoFile, JSON.stringify(persisted, null, 2));
+
+      const live = (manager as any).live.get(persisted.id);
+      live.proc.stdout.emit("data", Buffer.from(`${JSON.stringify({ type: "agent_start" })}\n`));
+      expect((await wait).responses).toEqual([
+        expect.objectContaining({ agent_name: "/worker", status: "completed", finalResponse: "persisted response" }),
+      ]);
+      expect(completions).toEqual([]);
+    } finally {
+      await manager.shutdown();
+      fs.rmSync(scope, { recursive: true, force: true });
+      delete process.env.PI_SUBAGENT_PI_BIN;
+    }
+  });
+
+  test("automatically delivers an adopted terminal state observed through process exit once", async () => {
+    process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
+    const parentSessionId = "completion-external-exit";
+    const scope = path.join(getRunsDir(), parentScopeKey(parentSessionId));
+    fs.rmSync(scope, { recursive: true, force: true });
+    const completions: any[] = [];
+    const manager = new AgentManager({ onUnclaimedCompletion: (event: any) => completions.push(event) });
+    try {
+      await manager.spawnAgent(spawnParams(parentSessionId, "worker", "hold external"));
+      const persisted = manager.getAgentInfo("worker", parentSessionId);
+      persisted.status = "failed";
+      persisted.error = "persisted failure";
+      persisted.completedAt = Date.now();
+      fs.writeFileSync(persisted.infoFile, JSON.stringify(persisted, null, 2));
+
+      process.kill(persisted.childProcess!.pid, "SIGKILL");
+      await waitUntil(() => completions.length === 1);
+      expect(completions[0]).toMatchObject({ agentName: "/worker", status: "failed", error: "persisted failure" });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(completions).toHaveLength(1);
+    } finally {
+      await manager.shutdown();
+      fs.rmSync(scope, { recursive: true, force: true });
+      delete process.env.PI_SUBAGENT_PI_BIN;
+    }
+  });
+
   test("suppresses automatic delivery while wait tools claim completions", async () => {
     process.env.PI_SUBAGENT_PI_BIN = FAKE_RPC_CHILD;
     const parentSessionId = "completion-waits";

--- a/packages/pi-codex-subagents/core.ts
+++ b/packages/pi-codex-subagents/core.ts
@@ -1179,8 +1179,7 @@ export class AgentManager {
       live.processFinished = true;
       const persisted = readInfoFile(live.info.infoFile);
       if (persisted && FINAL_STATUSES.has(persisted.status)) {
-        live.info = persisted;
-        live.finalizedRun = true;
+        this.adoptTerminalState(live, persisted);
       }
       for (const [requestId, pending] of live.pending) {
         clearTimeout(pending.timer);
@@ -1220,8 +1219,7 @@ export class AgentManager {
       if (!live.expectedExit) {
         const persisted = readInfoFile(live.info.infoFile);
         if (persisted && FINAL_STATUSES.has(persisted.status)) {
-          live.info = persisted;
-          live.finalizedRun = true;
+          this.adoptTerminalState(live, persisted);
         } else if (!live.finalizedRun) {
           this.markFailed(live, error.message);
         }
@@ -1340,8 +1338,7 @@ export class AgentManager {
     }
     const persisted = readInfoFile(live.info.infoFile);
     if (persisted && FINAL_STATUSES.has(persisted.status) && persisted.status !== live.info.status) {
-      live.info = persisted;
-      live.finalizedRun = true;
+      this.adoptTerminalState(live, persisted);
       return;
     }
     if (live.finalizedRun || live.expectedExit) return;
@@ -1389,6 +1386,22 @@ export class AgentManager {
         live.logger.info("hibernate", "failed to terminate settled child", { error: error instanceof Error ? error.message : String(error) });
       });
     }
+  }
+
+  private adoptTerminalState(live: LiveAgent, persisted: AgentInfo): void {
+    if (live.finalizedRun) return;
+    live.info = persisted;
+    live.finalizedRun = true;
+    this.notifyStatusChange(persisted);
+    this.pushMailbox({
+      id: randomUUID(),
+      parentSessionId: persisted.parentSessionId,
+      agentName: persisted.canonicalName,
+      status: persisted.status,
+      finalResponse: persisted.finalResponse,
+      error: persisted.error,
+      createdAt: Date.now(),
+    });
   }
 
   private markCompleted(live: LiveAgent): void {


### PR DESCRIPTION
fixes https://github.com/ogulcancelik/pi-extensions/issues/32

this doesn't fix the root problem, which is that codex-subagents really doesn't expect two managers to be running in parallel, but it papers over it by noticing when another manager has interfered rather than hanging forever.

the rest of this PR description was written by my llm.

---

When another manager persisted a terminal state first, child output, stdin failure, and process exit marked the local run finalized without publishing its completion. Route every such observation through one guarded adoption transition so active waiters, wait-all claims, and automatic delivery receive the result exactly once.

Regression tests force all three observation paths and verify waiter delivery, wait-all suppression, and one unclaimed automatic completion.