### PR TITLE
fix(subagents): ignore malformed run metadata

### DIFF
--- a/packages/pi-codex-subagents/core.test.ts
+++ b/packages/pi-codex-subagents/core.test.ts
@@ -134,6 +134,25 @@ describe("run storage", () => {
     }
   });
 
+  test("ignores malformed info records during reconciliation", async () => {
+    fs.rmSync(configFile, { force: true });
+    const parentSessionId = "malformed-info";
+    const scope = path.join(getRunsDir(), parentScopeKey(parentSessionId));
+    const malformed = path.join(scope, "33333333-3333-4333-8333-333333333333.info.json");
+    fs.rmSync(scope, { recursive: true, force: true });
+    fs.mkdirSync(scope, { recursive: true });
+    fs.writeFileSync(malformed, "{}");
+    const manager = new AgentManager();
+    try {
+      await manager.ready();
+      expect(manager.listAgents(undefined, parentSessionId)).toEqual([]);
+      expect(fs.existsSync(malformed)).toBe(true);
+    } finally {
+      await manager.shutdown();
+      fs.rmSync(scope, { recursive: true, force: true });
+    }
+  });
+
   test("removes expired runs and outputs using configurable retention", () => {
     fs.mkdirSync(packageDir, { recursive: true });
     fs.rmSync(fixtureDir, { recursive: true, force: true });

--- a/packages/pi-codex-subagents/core.ts
+++ b/packages/pi-codex-subagents/core.ts
@@ -416,7 +416,7 @@ function readInfos(directory: string): AgentInfo[] {
     .filter((name) => name.endsWith(".info.json"))
     .flatMap((name) => {
       const info = readInfoFile(path.join(directory, name));
-      return info ? [info] : [];
+      return info && typeof info.id === "string" && AGENT_ID_PATTERN.test(info.id) ? [info] : [];
     });
 }
 


### PR DESCRIPTION
note from jyn: i don't think this bug is super important, but it does make writing tests harder, so it seems nice to fix.

the rest of this PR was written by my llm.

---

A parseable but structurally incomplete info file entered reconciliation and crashed creation-order sorting. Accept only records with UUID-shaped agent IDs, leaving malformed files untouched for diagnosis.

Add a regression that reconciles and lists a scope containing an empty metadata object.