### PR TITLE
feat(codex-subagents): show resolved model details

### DIFF
--- a/packages/pi-codex-subagents/core.test.ts
+++ b/packages/pi-codex-subagents/core.test.ts
@@ -27,6 +27,15 @@ const {
   parseAgentDefinitionText,
   taskStorageKey,
 } = await import("./core.js");
+const { formatAgentSpecLines } = await import("./peek.js");
+
+
+test("formats the resolved subagent model and thinking for the detail overlay", () => {
+  expect(formatAgentSpecLines({ provider: "openai-codex", modelId: "gpt-5.5", thinking: "high" })).toEqual([
+    "Model: openai-codex/gpt-5.5",
+    "Thinking: high",
+  ]);
+});
 
 describe("RPC framing", () => {
   test("explains quota errors that Node leaves unnamed", () => {
@@ -741,10 +750,13 @@ describe("extension completion delivery and TUI", () => {
       const secondAgentPage = await tools.get("list_agents").execute("list-2", { offset: 10 }, undefined, undefined, ctx);
       expect(JSON.parse(secondAgentPage.content[0].text)).toMatchObject({ total: 12, returned: 2, offset: 10, next_offset: null });
 
-      await tools.get("spawn_agent").execute("spawn-1", {
+      const spawnResult = await tools.get("spawn_agent").execute("spawn-1", {
         task_name: "x".repeat(200),
         message: "slow finish",
       }, undefined, undefined, ctx);
+
+      const spawnRendered = tools.get("spawn_agent").renderResult(spawnResult, {}, { fg: (_color: string, text: string) => text }).render(400);
+      expect(spawnRendered.join("\n").trim()).toBe(`✓ ${spawnResult.details.task_name} · test/fake · high`);
 
       expect(widget).toBeFunction();
       const theme = { fg: (_color: string, text: string) => text };

--- a/packages/pi-codex-subagents/index.ts
+++ b/packages/pi-codex-subagents/index.ts
@@ -244,7 +244,13 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
           model,
           thinking: params.thinking,
         });
-        return textResult(`Spawned ${result.task_name}.`, result);
+        const info = manager.getAgentInfo(result.task_name, parentSessionId(ctx));
+        return textResult(`Spawned ${result.task_name}.`, {
+          ...result,
+          provider: info.provider,
+          modelId: info.modelId,
+          thinking: info.thinking,
+        });
       } catch (error) {
         throw new Error(`spawn_agent failed: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -254,7 +260,11 @@ ${cachedSkills.length ? cachedSkills.map((skill) => `- \`${skill.name}\` — ${s
     },
     renderResult(result: any, _options: any, theme: Theme) {
       if (result.isError) return new Text(theme.fg("error", `✗ ${result.content?.[0]?.text || "failed"}`), 0, 0);
-      return new Text(theme.fg("success", `✓ ${result.details?.task_name || "spawned"}`), 0, 0);
+      const model = result.details?.provider && result.details?.modelId
+        ? ` · ${result.details.provider}/${result.details.modelId}`
+        : "";
+      const thinking = result.details?.thinking ? ` · ${result.details.thinking}` : "";
+      return new Text(theme.fg("success", `✓ ${result.details?.task_name || "spawned"}${model}${thinking}`), 0, 0);
     },
   };
 

--- a/packages/pi-codex-subagents/peek.ts
+++ b/packages/pi-codex-subagents/peek.ts
@@ -24,6 +24,13 @@ function stripPromptMarkers(lines: string[]): string[] {
   return lines.map((line) => line.replace(OSC133_PROMPT_MARKER_RE, ""));
 }
 
+export function formatAgentSpecLines(info: Pick<AgentInfo, "provider" | "modelId" | "thinking">): string[] {
+  return [
+    `Model: ${info.provider}/${info.modelId}`,
+    `Thinking: ${info.thinking || "off"}`,
+  ];
+}
+
 export class SubagentPeekOverlay {
   private readonly sessionFile: string;
   private readonly cwd: string;
@@ -359,7 +366,8 @@ export class SubagentPeekOverlay {
     let contentLines: string[];
     if (this.cachedLines && this.cachedWidth === innerWidth) contentLines = this.cachedLines;
     else {
-      contentLines = stripPromptMarkers(this.chatContainer.render(innerWidth));
+      const specLines = formatAgentSpecLines(this.info).map((line) => this.theme.fg("dim", line));
+      contentLines = [...specLines, "", ...stripPromptMarkers(this.chatContainer.render(innerWidth))];
       this.cachedLines = contentLines;
       this.cachedWidth = innerWidth;
     }


### PR DESCRIPTION
## Summary

- show the resolved `provider/model` and thinking level in the `/subagents` detail overlay
- include the same resolved model spec in successful `spawn_agent` rendering
- preserve the compact activity widget and `list_agents` response unchanged

The displayed values come from the persisted `AgentInfo`, so explicit, template-provided, and inherited routing all report the model the child actually received.

## UI

```text
Model: openai-codex/gpt-5.5
Thinking: high
```

```text
✓ code-review · openai-codex/gpt-5.5 · high
```

## Tests

- `bun test packages/pi-codex-subagents/core.test.ts` — 25 pass, 0 fail
- `git diff --check`

The repository-wide suite also reaches the changed package successfully, but has two unrelated existing macOS path-alias failures in `pi-herdr-worktree-jump` (`/var/tmp` vs `/private/var/tmp`).
